### PR TITLE
Changed $field_value array check

### DIFF
--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -160,7 +160,7 @@ class EntityDataContext extends SharedDrupalContext
         $wrapper = entity_metadata_wrapper($this->currentEntityType, $this->currentEntity);
 
         $field_value = $wrapper->$field->value();
-        if (is_array($field_value) === true) {
+        if (is_array($field_value) === false) {
             $field_value = array($field_value);
         }
 


### PR DESCRIPTION
This pull request address issue #13 where _Then entity field :field should contain :value_ would fail on any test.

The code was updated to meet coding standards and the following line was incorrectly updated:

```
$field_value = is_array($field_value) ? $field_value : array($field_value);
```

This pull request fixes the conversion and maintains the new coding standard.
