### PR TITLE
Handle single value fields reliably in entity reference fields.

### DIFF
--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -347,12 +347,12 @@ class EntityDataContext extends SharedDrupalContext
     public function assertEntityFieldValueEntityReference($field, $value)
     {
         $field_info = field_info_field($field);
-        $items = field_get_items($this->currentEntityType, $this->currentEntity, $field);
+        $items      = field_get_items($this->currentEntityType, $this->currentEntity, $field);
 
         if (empty($items) === false) {
             foreach ($items as $item) {
                 $entities = entity_load($field_info['settings']['target_type'], $item);
-                $label = entity_label($field_info['settings']['target_type'], current($entities));
+                $label    = entity_label($field_info['settings']['target_type'], current($entities));
                 if ($label === $value) {
                     return;
                 }


### PR DESCRIPTION
entity_metadata_wrapper() and its ->value() method will return a single entity
object or an array of entity objects, depending on either the field configuration
or the field contents. It's kind of unpredictable, and rather than working around
it, this PR uses the more consistent field_get_items() from Drupal core.
