### PR TITLE
Replace files rather than copying them with a new name

### DIFF
--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -155,9 +155,9 @@ class SharedDrupalContext extends RawDrupalContext
      */
     public function fileCreate($file)
     {
-        // Save the file.
+        // Save the file and overwrite if it already exists.
         $dest   = file_build_uri(drupal_basename($file->uri));
-        $result = file_copy($file, $dest);
+        $result = file_copy($file, $dest, FILE_EXISTS_REPLACE);
 
         // Stash the file object for later cleanup.
         if (empty($result->fid) === false) {


### PR DESCRIPTION
Files that are copied as part of a Behat test can be given a new, unique filename if that file already exists. This can cause tests to fail. Instead, we replace the file and maintain the same filename.
