### PR TITLE
Don't use entity_metadata_wrapper() for text field contents, because …

### DIFF
--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -240,6 +240,10 @@ class EntityDataContext extends SharedDrupalContext
     {
         $items = field_get_items($this->currentEntityType, $this->currentEntity, $field);
 
+        if ($items === false) {
+            throw new \Exception(sprintf('No field data available for "%s".', $field));
+        }
+
         foreach ($items as $item) {
             if (strpos($item['value'], $value) !== false) {
                 return;


### PR DESCRIPTION
…it's too unpredictable.

Fixes an issue where sometimes the value returned by `entity_metadata_wrapper()` is an array of strings, which wasn't accounted for. `field_get_items()` will give us a more predictable result.
