### PR TITLE
Add support for loading nodes, fields, and paragraphs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "palantirnet/palantir-behat-extension": "dev-feature/entity-context",
+    "name": "palantirnet/palantir-behat-extension",
     "description": "Additional step definitions for testing Drupal sites using Behat.",
     "type": "behat-extension",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "palantirnet/palantir-behat-extension",
+    "name": "palantirnet/palantir-behat-extension": "dev-feature/entity-context",
     "description": "Additional step definitions for testing Drupal sites using Behat.",
     "type": "behat-extension",
     "keywords": [

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -346,6 +346,39 @@ class EntityDataContext extends SharedDrupalContext
 
     }//end assertNotEntityFieldValue()
 
+    /**
+     * Verify that a field contains a value.
+     *
+     * @Then paragraph field :field should be of type :type
+     *
+     * @param string $field_name A Drupal field name.
+     * @param mixed  $type The type of paragraph.
+     *
+     * @return void
+     */
+    public function assertEntityFieldValueParagraph($field_name, $type)
+    {
+      /**
+       * @var $field \Drupal\Core\Field\FieldItemList
+       */
+      $field = $this->currentEntity->get($field_name);
+
+      $types = [];
+
+      /**
+       * @var $entity \Drupal\paragraphs\Entity\Paragraph
+       */
+      foreach ($field->referencedEntities() as $entity) {
+          $types[] = $entity->getType();
+      }
+
+      if (!in_array($type, $types)) {
+          throw new \Exception(sprintf('Paragraph does not have type "%s", has types "%s".', $type, json_encode($types)));
+      }
+
+
+    }//end assertEntityFieldValue()
+
 
     /**
      * Test a link field for its URL value.
@@ -472,13 +505,17 @@ class EntityDataContext extends SharedDrupalContext
             $titles = [];
 
             /**
-             * @var $entity \Drupal\Core\Entity\EntityInterface
+             * @var $entity \Drupal\Core\Entity\ContentEntityBase
              */
             foreach ($entities as $entity) {
 
                 switch ($entity->getEntityTypeId()) {
                     case 'node':
                         $title = $entity->title->value;
+                        break;
+
+                    case 'paragraph':
+                        throw new \Exception('Paragraphs do not have titles, so they must be tested by a different method.');
                         break;
 
                     case 'taxonomy_term':
@@ -502,6 +539,22 @@ class EntityDataContext extends SharedDrupalContext
         throw new \Exception('Field is empty.');
 
     }//end assertEntityFieldValueEntityReference()
+
+
+    /**
+     * Passes handling to the generic Entity Reference method.
+     *
+     * @param \Drupal\Core\Field\FieldItemList $field A Drupal field object.
+     * @param mixed  $value The value to look for.
+     *
+     * @throws \Exception
+     *
+     * @return void
+     */
+    public function assertEntityFieldValueEntityReferenceRevisions($field, $value)
+    {
+        $this->assertEntityFieldValueEntityReference($field, $value);
+    }//end assertEntityFieldValueEntityReferenceRevisions()
 
 
     /**

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -477,12 +477,15 @@ class EntityDataContext extends SharedDrupalContext
             foreach ($entities as $entity) {
 
                 switch ($entity->getEntityTypeId()) {
+                    case 'node':
+                        $title = $entity->title->value;
+                        break;
+
                     case 'taxonomy_term':
                     case 'user':
-                        $title = $entity->name->value;
-                        break;
+                    case 'media':
                     default:
-                        $title = $entity->title->value;
+                        $title = $entity->name->value;
                         break;
                 }
 

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -107,9 +107,8 @@ class EntityDataContext extends SharedDrupalContext
      */
     public function assertEntityPropertyValue($property, $value)
     {
-        if ($this->currentEntity->$property->value !== $value) {
-            throw new \Exception(sprintf('Property "%s" is not "%s"', $property, $value));
-        }
+        // Properties and fields are accessed in the same way in Drupal 8.
+        $this->assertEntityFieldValue($property, $value);
 
     }//end assertEntityPropertyValue()
 

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -28,6 +28,9 @@ use Palantirnet\PalantirBehatExtension\NotUpdatedException;
 class EntityDataContext extends SharedDrupalContext
 {
 
+    /**
+     * @var $currentEntity \Drupal\Core\Entity\EntityInterface
+     */
     protected $currentEntity     = null;
     protected $currentEntityType = null;
 
@@ -464,7 +467,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Test an entity reference field for an entity label.
      *
-     * @param string $field A Drupal field name.
+     * @param object $field A Drupal field object.
      * @param mixed  $value The value to look for.
      *
      * @throws \Exception
@@ -478,10 +481,24 @@ class EntityDataContext extends SharedDrupalContext
         if (empty($entities) === false) {
             $titles = [];
 
+            /**
+             * @var $entity \Drupal\Core\Entity\EntityInterface
+             */
             foreach ($entities as $entity) {
-                $titles[] = $entity->title->value;
 
-                if ($entity->title->value === $value) {
+                switch ($entity->getEntityTypeId()) {
+                    case 'taxonomy_term':
+                    case 'user':
+                        $title = $entity->name->value;
+                        break;
+                    default:
+                        $title = $entity->title->value;
+                        break;
+                }
+
+                $titles[] = $title;
+
+                if ($title === $value) {
                     return;
                 }
             }

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -391,21 +391,11 @@ class EntityDataContext extends SharedDrupalContext
      */
     public function assertEntityFieldValueTextLong($field, $value)
     {
-        throw new NotUpdatedException('Method not yet updated for Drupal 8.');
-
-        $items = field_get_items($this->currentEntityType, $this->currentEntity, $field);
-
-        if ($items === false) {
-            throw new \Exception(sprintf('No field data available for "%s".', $field));
+        if (strpos($field->value, $value) !== false) {
+            return;
         }
 
-        foreach ($items as $item) {
-            if (strpos($item['value'], $value) !== false) {
-                return;
-            }
-        }
-
-        throw new \Exception(sprintf('Field "%s" does not contain partial text "%s"', $field, $value));
+        throw new \Exception(sprintf('Field does not contain partial text "%s", contains "%s"', $value, json_encode($field->value)));
 
     }//end assertEntityFieldValueTextLong()
 

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -417,26 +417,16 @@ class EntityDataContext extends SharedDrupalContext
      *
      * @throws \Exception
      */
-    public function assertEntityFieldValueLinkField($field, $value)
+    public function assertEntityFieldValueLink($field, $value)
     {
-        throw new NotUpdatedException('Method not yet updated for Drupal 8.');
+      if (strpos($field->getValue()[0]['uri'], $value) !== false) {
+        return;
+      }
 
-        $wrapper = entity_metadata_wrapper($this->currentEntityType, $this->currentEntity);
+      throw new \Exception(sprintf('Field does not contain the url "%s", contains "%s"', $value, json_encode($field->getValue()[0]['uri'])));
 
-        $field_value = $wrapper->$field->value();
-        if (isset($field_value['url']) === true) {
-            $field_value = array($field_value);
-        }
+    }//end assertEntityFieldValueLink()
 
-        foreach ($field_value as $f) {
-            if ($f['url'] === $value) {
-                return;
-            }
-        }
-
-        throw new \Exception(sprintf('Field "%s" does not contain "%s"', $field, $value));
-
-    }//end assertEntityFieldValueLinkField()
 
 
     /**

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -273,7 +273,7 @@ class EntityDataContext extends SharedDrupalContext
      *
      * @Then entity field :field should contain :value
      *
-     * @param string $field A Drupal field name.
+     * @param string $field_name A Drupal field name.
      * @param mixed  $value The value to look for.
      *
      * @return void
@@ -350,7 +350,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Test a link field for its URL value.
      *
-     * @param string $field A Drupal field name.
+     * @param \Drupal\Core\Field\FieldItemList $field A Drupal field name.
      * @param mixed  $value The value to look for.
      *
      * @return void
@@ -382,7 +382,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Test a text field for a partial string.
      *
-     * @param string $field A Drupal field name.
+     * @param \Drupal\Core\Field\FieldItemList $field A Drupal field name.
      * @param mixed  $value The value to look for.
      *
      * @throws \Exception
@@ -413,7 +413,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Test a file field for a Drupal stream wrapper URI.
      *
-     * @param string $field A Drupal field name.
+     * @param \Drupal\Core\Field\FieldItemList $field A Drupal field name.
      * @param mixed  $value The value to look for.
      *
      * @throws \Exception
@@ -448,7 +448,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Test an image field for a Drupal stream wrapper URI.
      *
-     * @param string $field A Drupal field name.
+     * @param \Drupal\Core\Field\FieldItemList $field A Drupal field name.
      * @param mixed  $value The value to look for.
      *
      * @throws \Exception
@@ -467,7 +467,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Test an entity reference field for an entity label.
      *
-     * @param object $field A Drupal field object.
+     * @param \Drupal\Core\Field\FieldItemList $field A Drupal field object.
      * @param mixed  $value The value to look for.
      *
      * @throws \Exception
@@ -514,7 +514,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Test a date field for some date.
      *
-     * @param string $field A Drupal field name.
+     * @param \Drupal\Core\Field\FieldItemList $field A Drupal field name.
      * @param mixed  $value The value to look for.
      *
      * @throws \Exception

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -400,7 +400,7 @@ class EntityDataContext extends SharedDrupalContext
     }//end assertNotEntityFieldValue()
 
     /**
-     * Verify that a field contains a value.
+     * Verify that a paragraph field contains a paragraph of a certain type.
      *
      * @Then paragraph field :field should be of type :type
      *
@@ -552,31 +552,21 @@ class EntityDataContext extends SharedDrupalContext
              */
             foreach ($entities as $entity) {
 
-                switch ($entity->getEntityTypeId()) {
-                    case 'node':
-                        $title = $entity->title->value;
-                        break;
-
-                    case 'paragraph':
-                        throw new \Exception('Paragraphs do not have titles, so they must be tested by a different method.');
-                        break;
-
-                    case 'taxonomy_term':
-                    case 'user':
-                    case 'media':
-                    default:
-                        $title = $entity->name->value;
-                        break;
+                if ($entity->getEntityTypeId() === 'paragraph') {
+                     throw new \Exception('Paragraphs do not have meaningful labels, so they must be tested by a different method.');
+                    // If we get a single paragraph reference, we will assume
+                    // that the rest are also paragraphs and exit the method.
+                    return;
                 }
 
-                $titles[] = $title;
+                $labels[] = $entity->label();
 
-                if ($title === $value) {
+                if ($entity->label() === $value) {
                     return;
                 }
             }
 
-            throw new \Exception(sprintf('Field does not contain entity with title "%s" (has "%s" titles instead).', $value, json_encode($titles)));
+            throw new \Exception(sprintf('Field does not contain entity with label "%s" (has "%s" labels instead).', $value, json_encode($labels)));
         }
 
         throw new \Exception('Field is empty.');

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -512,52 +512,17 @@ class EntityDataContext extends SharedDrupalContext
      * @return void
      *
      * @todo : Update method to handle date fields with start and end dates
-     * The call to $wrapper->$field->value() returns either an array or a scalar
-     * because entity_metadata_wrapper() makes the date field values array
-     * unpredictable. When working with date fields that have both a start and
-     * end time, an array is returned instead of a scalar. If we want to test
-     * for start and end dates, we would want to use Behat syntax similar to
+     * If we want to test for start and end dates, we would want to use Behat syntax
      * "Then entity field ":field should contain "<start_date> - <end_date>".
-     * This method would need to be updated to handle that approach.
      */
     public function assertEntityFieldValueDatetime($field, $value)
     {
-        throw new NotUpdatedException('Method not yet updated for Drupal 8.');
 
-        $wrapper     = entity_metadata_wrapper($this->currentEntityType, $this->currentEntity);
-        $field_value = $wrapper->$field->value();
-
-        if (is_scalar($field_value) === true) {
-            $field_value = array($field_value);
+        if (strtotime($field->value) === strtotime($value)) {
+          return;
         }
 
-        if (is_array($field_value) === false) {
-            $field_value = array();
-        }
-
-        foreach ($field_value as $v) {
-            if (is_array($v) === true) {
-                // The value may exist as either the start date ('value') or the end
-                // date ('value2').
-                if (array_key_exists('value', $v) === true) {
-                    if (strtotime($value) === strtotime($v['value'])) {
-                        return;
-                    }
-                }
-
-                if (array_key_exists('value2', $v) === true) {
-                    if (strtotime($value) === strtotime($v['value2'])) {
-                        return;
-                    }
-                }
-            }
-
-            if (strtotime($value) === $v) {
-                return;
-            }
-        }//end foreach
-
-        throw new \Exception(sprintf('Field "%s" does not contain datetime "%s" (%s)', $field, strtotime($value), $value));
+        throw new \Exception(sprintf('Field does not contain datetime "%s" (%s), contains "%s".', strtotime($value), $value, strtotime($field->value)));
 
     }//end assertEntityFieldValueDatetime()
 

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -277,6 +277,9 @@ class EntityDataContext extends SharedDrupalContext
      */
     public function assertEntityFieldValue($field_name, $value)
     {
+        /**
+         * @var $field \Drupal\Core\Field\FieldItemList
+         */
         $field = $this->currentEntity->get($field_name);
 
         /**
@@ -284,7 +287,7 @@ class EntityDataContext extends SharedDrupalContext
          */
         $definition = $field->getFieldDefinition();
 
-        $field_type = $definition->get('field_type');
+        $field_type = $definition->getType();
 
         // If a method exists to handle this field type, use it.
         $method_name = 'assertEntityFieldValue'.str_replace(' ', '', ucwords(str_replace('_', ' ', $field_type)));
@@ -292,7 +295,7 @@ class EntityDataContext extends SharedDrupalContext
             return $this->$method_name($field, $value);
         }
 
-        $field_value = $field->getValue();
+        $field_value = $field->value;
 
         // Special case for expecting nothing
         if ($value === 'nothing') {

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -98,6 +98,33 @@ class EntityDataContext extends SharedDrupalContext
     }//end assertUserByName()
 
 
+  /**
+   * @When I examine paragraph ":fieldWeight" on the ":fieldName" field
+   *
+   * This can drill down into a paragraph on a loaded entity.
+   */
+    public function assertParagraphByWeight($fieldWeight, $fieldName)
+    {
+        if (!$this->currentEntity->hasField($fieldName)) {
+            throw new \Exception('Could not load the field');
+        }
+
+        $field = $this->currentEntity->get($fieldName);
+
+        $paragraphs = $field->referencedEntities();
+
+        if (!(is_array($paragraphs) && isset($paragraphs[$fieldWeight - 1]))){
+            throw new \Exception('Could not find the paragraph in the field.');
+        }
+
+        $paragraph = $paragraphs[$fieldWeight - 1];
+
+        $this->currentEntity = $paragraph;
+        $this->currentEntityType = 'paragraph';
+
+    }//end assertParagraphByWeight()
+
+
     /**
      * Verify that an entity property is equal to a particular value.
      *

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -523,7 +523,7 @@ class EntityDataContext extends SharedDrupalContext
             throw new \Exception(sprintf('Field does not contain entity with title "%s" (has "%s" titles instead).', $value, json_encode($titles)));
         }
 
-        throw new \Exception(sprintf('Field "%s" is empty.', $field));
+        throw new \Exception('Field is empty.');
 
     }//end assertEntityFieldValueEntityReference()
 

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -33,6 +33,7 @@ class EntityDataContext extends SharedDrupalContext
      */
     protected $currentEntity     = null;
     protected $currentEntityType = null;
+    protected $currentEntityLanguage = null;
 
 
     /**
@@ -53,6 +54,27 @@ class EntityDataContext extends SharedDrupalContext
         $this->currentEntityType = 'node';
 
     }//end assertNodeByTitle()
+
+    /**
+     * Verify field and property values of a node entity in a language.
+     *
+     * @When I examine the :contentType( node) with title :title in :language
+     *
+     * @param string $contentType A Drupal content type machine name.
+     * @param string $title       The title of a Drupal node.
+     * @param string $language    A language code
+     *
+     * @return void
+     */
+    public function assertNodeByTitleAndLanguage($contentType, $title, $language)
+    {
+      $node = $this->findNodeByTitle($contentType, $title, $language);
+
+      $this->currentEntity     = $node;
+      $this->currentEntityType = 'node';
+      $this->currentEntityLanguage = $language;
+
+    }//end assertNodeByTitleAndLanguage()
 
 
     /**
@@ -118,6 +140,10 @@ class EntityDataContext extends SharedDrupalContext
         }
 
         $paragraph = $paragraphs[$fieldWeight - 1];
+
+        if (isset($this->currentEntityLanguage) && $paragraph->hasTranslation($this->currentEntityLanguage)){
+          $paragraph = $paragraph->getTranslation($this->currentEntityLanguage);
+        }
 
         $this->currentEntity = $paragraph;
         $this->currentEntityType = 'paragraph';

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -462,42 +462,6 @@ class EntityDataContext extends SharedDrupalContext
 
 
     /**
-     * Test a taxonomy term reference field for a term name.
-     *
-     * @param string $field A Drupal field name.
-     * @param mixed  $value The value to look for.
-     *
-     * @throws \Exception
-     *
-     * @return void
-     */
-    public function assertEntityFieldValueTaxonomyTermReference($field, $value)
-    {
-        throw new NotUpdatedException('Method not yet updated for Drupal 8.');
-
-        $wrapper = entity_metadata_wrapper($this->currentEntityType, $this->currentEntity);
-
-        $field_value = $wrapper->$field->value();
-
-        if (empty($field_value) === false) {
-            // Term field values are term objects.
-            if (is_array($field_value) === false) {
-                $field_value = array($field_value);
-            }
-
-            foreach ($field_value as $term) {
-                if (is_object($term) === true && empty($term->name) === false && $term->name === $value) {
-                    return;
-                }
-            }
-        }
-
-        throw new \Exception(sprintf('Field "%s" does not contain term "%s"', $field, $value));
-
-    }//end assertEntityFieldValueTaxonomyTermReference()
-
-
-    /**
      * Test an entity reference field for an entity label.
      *
      * @param string $field A Drupal field name.

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -51,6 +51,11 @@ class SharedDrupalContext extends RawDrupalContext
         if (count($entities) === 1) {
             $node_storage = \Drupal::entityManager()->getStorage('node');
 
+            // `entityQuery` will return an array of node IDs with key and
+            // value equal to the nids.
+            // Example: `[123 => '123', 456 => '456']`. For this reason, even
+            // though there is only a single element, we cannot access the
+            // first element using `$entities[0]`.
             $nid = array_shift($entities);
 
             $node = $node_storage->load($nid);

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -38,19 +38,23 @@ class SharedDrupalContext extends RawDrupalContext
      */
     public function findNodeByTitle($contentType, $title)
     {
-        throw new NotUpdatedException('Method not yet updated for Drupal 8.');
+        /**
+         * @var $query \Drupal\Core\Entity\Query\QueryInterface
+         */
+        $query = \Drupal::entityQuery('node');
 
-        $query = new \EntityFieldQuery();
-
-        $entities = $query->entityCondition('entity_type', 'node')
-            ->entityCondition('bundle', $contentType)
-            ->propertyCondition('title', $title)
+        $entities = $query
+            ->condition('type', $contentType)
+            ->condition('title', $title)
             ->execute();
 
-        if (empty($entities['node']) === false && count($entities['node']) === 1) {
-            $nid = key($entities['node']);
-            return node_load($nid);
-        } else if (empty($entities['node']) === false && count($entities['node']) > 1) {
+        if (count($entities) === 1) {
+            $node_storage = \Drupal::entityManager()->getStorage('node');
+
+            $nid = array_shift($entities);
+
+            return $node_storage->load($nid);
+        } else if (count($entities) > 1) {
             throw new \Exception(sprintf('Found more than one "%s" node entitled "%s"', $contentType, $title));
         } else {
             throw new \Exception(sprintf('No "%s" node entitled "%s" exists', $contentType, $title));

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -36,7 +36,7 @@ class SharedDrupalContext extends RawDrupalContext
      * @return stdclass
      *   The Drupal node object, if it exists.
      */
-    public function findNodeByTitle($contentType, $title)
+    public function findNodeByTitle($contentType, $title, $language = NULL)
     {
         /**
          * @var $query \Drupal\Core\Entity\Query\QueryInterface
@@ -53,7 +53,18 @@ class SharedDrupalContext extends RawDrupalContext
 
             $nid = array_shift($entities);
 
-            return $node_storage->load($nid);
+            $node = $node_storage->load($nid);
+
+            if (!is_null($language)) {
+              if ($node->hasTranslation($language)) {
+                $node = $node->getTranslation($language);
+              }
+              else {
+                throw new \Exception('The node is not available in that language.');
+              }
+            }
+
+            return $node;
         } else if (count($entities) > 1) {
             throw new \Exception(sprintf('Found more than one "%s" node entitled "%s"', $contentType, $title));
         } else {


### PR DESCRIPTION
Nodes can be loaded by type / title / language.
Fields can be loaded.
Entity references are loaded.
Special handling is used for fields with "nothing" values, they are checked to see if they are empty.

Special handling for:
- Entity references which includes nodes, terms, media
- Long text
- Date (not yet ranges)
- Links
- Translations
- Paragraph types in fields
- Fields on paragraphs

Example:
```
Scenario: Blog post exists
  When I examine the "blog_post" node with title "My post"
  Then entity field "field_simple_example" should contain "test"
  And entity field "field_is_a_thing" should contain "nothing"
  # Example entity reference
  And entity field "field_authors" should contain "John Smith"
  And paragraph field "field_paragraphs" should be of type "my_paragraph_type"

Scenario: Paragraph fields
  When I examine the "page" node with title "My page"
  And I examine paragraph "5" on the "field_paragraphs" field
  Then entity field "field_content" should contain "Example"

Scenario: Paragraph fields in English
  When I examine the "page" node with title "My page" in "en"
  And I examine paragraph "5" on the "field_paragraphs" field
  Then entity field "field_content" should contain "Example"
```