### PR TITLE
D8 support for blocks and additional field types

### DIFF
--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -237,7 +237,7 @@ class EntityDataContext extends SharedDrupalContext
      * @param array $roles
      *  An array of Drupal role objects.
      *
-     * @throws \Exception if user does not have one ore more roles as defined in $roles
+     * @throws \Exception if user does not have one or more roles as defined in $roles
      *
      * @return void
      */

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -10,7 +10,6 @@ namespace Palantirnet\PalantirBehatExtension\Context;
 use Behat\Behat\Tester\Exception\PendingException;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Drupal\DrupalDriverManager;
-use Drupal\user\Entity\Role;
 use Palantirnet\PalantirBehatExtension\NotUpdatedException;
 
 /**
@@ -32,7 +31,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * @var $currentEntity \Drupal\Core\Entity\EntityInterface
      */
-    protected $currentEntity     = null;
+    protected $currentEntity = null;
     protected $currentEntityType = null;
     protected $currentEntityLanguage = null;
 
@@ -43,7 +42,7 @@ class EntityDataContext extends SharedDrupalContext
      * @When I examine the :contentType( node) with title :title
      *
      * @param string $contentType A Drupal content type machine name.
-     * @param string $title       The title of a Drupal node.
+     * @param string $title The title of a Drupal node.
      *
      * @return void
      */
@@ -51,7 +50,7 @@ class EntityDataContext extends SharedDrupalContext
     {
         $node = $this->findNodeByTitle($contentType, $title);
 
-        $this->currentEntity     = $node;
+        $this->currentEntity = $node;
         $this->currentEntityType = 'node';
 
     }//end assertNodeByTitle()
@@ -62,18 +61,18 @@ class EntityDataContext extends SharedDrupalContext
      * @When I examine the :contentType( node) with title :title in :language
      *
      * @param string $contentType A Drupal content type machine name.
-     * @param string $title       The title of a Drupal node.
-     * @param string $language    A language code
+     * @param string $title The title of a Drupal node.
+     * @param string $language A language code
      *
      * @return void
      */
     public function assertNodeByTitleAndLanguage($contentType, $title, $language)
     {
-      $node = $this->findNodeByTitle($contentType, $title, $language);
+        $node = $this->findNodeByTitle($contentType, $title, $language);
 
-      $this->currentEntity     = $node;
-      $this->currentEntityType = 'node';
-      $this->currentEntityLanguage = $language;
+        $this->currentEntity = $node;
+        $this->currentEntityType = 'node';
+        $this->currentEntityLanguage = $language;
 
     }//end assertNodeByTitleAndLanguage()
 
@@ -115,7 +114,7 @@ class EntityDataContext extends SharedDrupalContext
     {
         $account = $this->findUserByName($userName);
 
-        $this->currentEntity     = $account;
+        $this->currentEntity = $account;
         $this->currentEntityType = 'user';
 
     }//end assertUserByName()
@@ -269,7 +268,7 @@ class EntityDataContext extends SharedDrupalContext
     {
         foreach ($roles as $role) {
             if (true === $account->hasRole($role->id())) {
-              throw new \Exception(sprintf('User "%s" has role "%s".', $account->name(), $role->label()));
+                throw new \Exception(sprintf('User "%s" has role "%s".', $account->name(), $role->label()));
             }
         }
 
@@ -298,14 +297,14 @@ class EntityDataContext extends SharedDrupalContext
             $rid = array_search($role_name, $r);
 
             if ($rid) {
-              $role = Role::load($rid);
+                $role = \Drupal\user\Entity\Role::load($rid);
             }
 
             if (FALSE === $role) {
                 throw new \Exception(sprintf('Role "%s" does not exist.', $role_name));
             }
 
-          $roles[$role->id()] = $role;
+            $roles[$role->id()] = $role;
         }
 
         return $roles;
@@ -466,7 +465,6 @@ class EntityDataContext extends SharedDrupalContext
       throw new \Exception(sprintf('Field does not contain the url "%s", contains "%s"', $value, json_encode($field->getValue()[0]['uri'])));
 
     }//end assertEntityFieldValueLink()
-
 
 
     /**

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -844,6 +844,25 @@ class EntityDataContext extends SharedDrupalContext
 
 
     /**
+     * Webforms act like entity reference fields. This function
+     * passes handling to the generic Entity Reference method.
+     *
+     * @param \Drupal\Core\Field\FieldItemList $field
+     *  A Drupal field object.
+     * @param mixed $value
+     *  The value to look for.
+     *
+     * @throws \Exception
+     *
+     * @return void
+     */
+    public function assertEntityFieldValueWebform($field, $value)
+    {
+        $this->assertEntityFieldValueEntityReference($field, $value);
+    }//end assertEntityFieldValueWebform()
+
+
+    /**
      * Test a date field for some date.
      *
      * @param \Drupal\Core\Field\FieldItemList $field

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -159,6 +159,58 @@ class EntityDataContext extends SharedDrupalContext
 
 
     /**
+     * Verify field and property values of a media entity.
+     *
+     * @When I examine the :mediaType media with name :name
+     *
+     * @param string $mediaType
+     *  A Drupal media type machine name.
+     * @param string $name
+     *  The name of a Drupal media entity.
+     *
+     * @throws \Exception if media is not found.
+     * @throws \Exception if multiple media entities with name $name are found.
+     *
+     * @return void
+     */
+    public function assertMediaByName($mediaType, $name)
+    {
+        $media = $this->findMediaByName($mediaType, $name);
+
+        $this->currentEntity = $media;
+        $this->currentEntityType = 'media';
+
+    }//end assertMediaByName()
+
+    /**
+     * Verify field and property values of a media entity.
+     *
+     * @When I examine the :mediaType media with name :name
+     *
+     * @param string $mediaType
+     *  A Drupal media type machine name.
+     * @param string $name
+     *  The name of a Drupal media entity.
+     * @param string $language
+     *  Optional language code.
+     *
+     * @throws \Exception if media is not found.
+     * @throws \Exception if multiple media entities with name $name are found.
+     *
+     * @return void
+     */
+    public function assertMediaByNameAndLanguage($mediaType, $name, $language)
+    {
+        $media = $this->findMediaByName($mediaType, $name, $language);
+
+        $this->currentEntity = $media;
+        $this->currentEntityType = 'media';
+        $this->currentEntityLanguage = $language;
+
+    }//end assertMediaByNameAndLanguage()
+
+
+    /**
      * Verify field and property values of a user entity.
      *
      * @When I examine the user :userName

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -211,24 +211,6 @@ class EntityDataContext extends SharedDrupalContext
 
 
     /**
-     * Verify that an entity property is equal to a particular value.
-     *
-     * @Then entity property :property should be :value
-     *
-     * @param string $property A Drupal entity property name.
-     * @param mixed  $value    The value to look for.
-     *
-     * @return void
-     */
-    public function assertEntityPropertyValue($property, $value)
-    {
-        // Properties and fields are accessed in the same way in Drupal 8.
-        $this->assertEntityFieldValue($property, $value);
-
-    }//end assertEntityPropertyValue()
-
-
-    /**
      * Verify that a user has one or more roles.
      *
      * @Then the user should have the role(s) :role
@@ -369,6 +351,26 @@ class EntityDataContext extends SharedDrupalContext
         return $roles;
 
     }//end getRoles()
+
+
+    /**
+     * Verify that an entity property is equal to a particular value.
+     *
+     * @Then entity property :property should be :value
+     *
+     * @param string $property
+     *  A Drupal entity property name.
+     * @param mixed $value
+     *  The value to look for.
+     *
+     * @return void
+     */
+    public function assertEntityPropertyValue($property, $value)
+    {
+        // Properties and fields are accessed in the same way in Drupal 8.
+        $this->assertEntityFieldValue($property, $value);
+
+    }//end assertEntityPropertyValue()
 
 
     /**
@@ -548,7 +550,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Verify a field does not contain a particular value.
      *
-     * @Then entity field :field should not contain :value
+     * @Then entity field :field should not contain :value for property :property
      *
      * @param string
      *  $field A Drupal field name.

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -100,6 +100,58 @@ class EntityDataContext extends SharedDrupalContext
 
 
     /**
+     * Verify field and property values of a block entity.
+     *
+     * @When I examine the :blockType block with info :info
+     *
+     * @param string $blockType
+     *  A Drupal block type machine name.
+     * @param string $info
+     *  The description of a Drupal block.
+     *
+     * @throws \Exception if block is not found.
+     * @throws \Exception if multiple blocks with info $info are found.
+     *
+     * @return void
+     */
+    public function assertBlockByInfo($blockType, $info)
+    {
+        $block = $this->findBlockByInfo($blockType, $info);
+
+        $this->currentEntity = $block;
+        $this->currentEntityType = 'block_content';
+
+    }//end assertBlockByInfo()
+
+    /**
+     * Verify field and property values of a block entity.
+     *
+     * @When I examine the :blockType block with info :info in :language
+     *
+     * @param string $blockType
+     *  A Drupal block type machine name.
+     * @param string $info
+     *  The info of a Drupal block.
+     * @param string $language
+     *  Optional language code.
+     *
+     * @throws \Exception if block is not found.
+     * @throws \Exception if multiple blocks with info $info are found.
+     *
+     * @return void
+     */
+    public function assertBlockByInfoAndLanguage($blockType, $info, $language)
+    {
+        $block = $this->findBlockByInfo($blockType, $info, $language);
+
+        $this->currentEntity = $block;
+        $this->currentEntityType = 'block_content';
+        $this->currentEntityLanguage = $language;
+
+    }//end assertBlockByInfoAndLanguage()
+
+
+    /**
      * Verify field and property values of a user entity.
      *
      * @When I examine the user :userName

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -185,7 +185,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Verify field and property values of a media entity.
      *
-     * @When I examine the :mediaType media with name :name
+     * @When I examine the :mediaType media with name :name in :language
      *
      * @param string $mediaType
      *  A Drupal media type machine name.

--- a/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/EntityDataContext.php
@@ -120,11 +120,11 @@ class EntityDataContext extends SharedDrupalContext
     }//end assertUserByName()
 
 
-  /**
-   * @When I examine paragraph ":fieldWeight" on the ":fieldName" field
-   *
-   * This can drill down into a paragraph on a loaded entity.
-   */
+    /**
+     * @When I examine paragraph ":fieldWeight" on the ":fieldName" field
+     *
+     * This can drill down into a paragraph on a loaded entity.
+     */
     public function assertParagraphByWeight($fieldWeight, $fieldName)
     {
         if (!$this->currentEntity->hasField($fieldName)) {
@@ -142,7 +142,7 @@ class EntityDataContext extends SharedDrupalContext
         $paragraph = $paragraphs[$fieldWeight - 1];
 
         if (isset($this->currentEntityLanguage) && $paragraph->hasTranslation($this->currentEntityLanguage)){
-          $paragraph = $paragraph->getTranslation($this->currentEntityLanguage);
+            $paragraph = $paragraph->getTranslation($this->currentEntityLanguage);
         }
 
         $this->currentEntity = $paragraph;
@@ -232,7 +232,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Verify that a user account has a set of roles.
      *
-     * @param \Drupal\Core\Entity\EntityInterface $account
+     * @param \Drupal\User\Entity\User $account
      *  A Drupal user account object.
      * @param array $roles
      *  An array of Drupal role objects.
@@ -245,7 +245,7 @@ class EntityDataContext extends SharedDrupalContext
     {
         foreach ($roles as $role) {
             if (false === $account->hasRole($role->id())) {
-                throw new \Exception(sprintf('User "%s" does not have role "%s".', $account->name(), $role->label()));
+                throw new \Exception(sprintf('User "%s" does not have role "%s".', $account->getAccountName(), $role->label()));
             }
         }
 
@@ -255,7 +255,7 @@ class EntityDataContext extends SharedDrupalContext
     /**
      * Verify that a user account does not have a set of roles.
      *
-     * @param \Drupal\Core\Entity\EntityInterface $account
+     * @param \Drupal\User\Entity\User $account
      *   A Drupal user account object.
      * @param array $roles
      *   An array of Drupal role objects.
@@ -268,7 +268,7 @@ class EntityDataContext extends SharedDrupalContext
     {
         foreach ($roles as $role) {
             if (true === $account->hasRole($role->id())) {
-                throw new \Exception(sprintf('User "%s" has role "%s".', $account->name(), $role->label()));
+                throw new \Exception(sprintf('User "%s" has role "%s".', $account->getAccountName(), $role->label()));
             }
         }
 
@@ -424,23 +424,23 @@ class EntityDataContext extends SharedDrupalContext
      */
     public function assertEntityFieldValueParagraph($field_name, $type)
     {
-      /**
-       * @var $field \Drupal\Core\Field\FieldItemList
-       */
-      $field = $this->currentEntity->get($field_name);
+        /**
+         * @var $field \Drupal\Core\Field\FieldItemList
+         */
+        $field = $this->currentEntity->get($field_name);
 
-      $types = [];
+        $types = [];
 
-      /**
-       * @var $entity \Drupal\paragraphs\Entity\Paragraph
-       */
-      foreach ($field->referencedEntities() as $entity) {
-          $types[] = $entity->getType();
-      }
+        /**
+         * @var $entity \Drupal\paragraphs\Entity\Paragraph
+         */
+        foreach ($field->referencedEntities() as $entity) {
+            $types[] = $entity->getType();
+        }
 
-      if (!in_array($type, $types)) {
-          throw new \Exception(sprintf('Paragraph does not have type "%s", has types "%s".', $type, json_encode($types)));
-      }
+        if (!in_array($type, $types)) {
+            throw new \Exception(sprintf('Paragraph does not have type "%s", has types "%s".', $type, json_encode($types)));
+        }
 
 
     }//end assertEntityFieldValue()
@@ -458,11 +458,11 @@ class EntityDataContext extends SharedDrupalContext
      */
     public function assertEntityFieldValueLink($field, $value)
     {
-      if (strpos($field->getValue()[0]['uri'], $value) !== false) {
-        return;
-      }
+        if (strpos($field->getValue()[0]['uri'], $value) !== false) {
+            return;
+        }
 
-      throw new \Exception(sprintf('Field does not contain the url "%s", contains "%s"', $value, json_encode($field->getValue()[0]['uri'])));
+        throw new \Exception(sprintf('Field does not contain the url "%s", contains "%s"', $value, json_encode($field->getValue()[0]['uri'])));
 
     }//end assertEntityFieldValueLink()
 
@@ -565,7 +565,7 @@ class EntityDataContext extends SharedDrupalContext
             foreach ($entities as $entity) {
 
                 if ($entity->getEntityTypeId() === 'paragraph') {
-                     throw new \Exception('Paragraphs do not have meaningful labels, so they must be tested by a different method.');
+                    throw new \Exception('Paragraphs do not have meaningful labels, so they must be tested by a different method.');
                     // If we get a single paragraph reference, we will assume
                     // that the rest are also paragraphs and exit the method.
                     return;
@@ -620,7 +620,7 @@ class EntityDataContext extends SharedDrupalContext
     {
 
         if (strtotime($field->value) === strtotime($value)) {
-          return;
+            return;
         }
 
         throw new \Exception(sprintf('Field does not contain datetime "%s" (%s), contains "%s".', strtotime($value), $value, strtotime($field->value)));

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -161,20 +161,20 @@ class SharedDrupalContext extends RawDrupalContext
         $query = \Drupal::entityQuery('user');
 
         $entities = $query
-          ->condition('name', $userName)
-          ->execute();
+            ->condition('name', $userName)
+            ->execute();
 
         if (count($entities) === 1) {
-          $user_storage = \Drupal::entityTypeManager()->getStorage('user');
-          $uid = array_shift($entities);
+            $user_storage = \Drupal::entityTypeManager()->getStorage('user');
+            $uid = array_shift($entities);
 
-          $user = $user_storage->load($uid);
+            $user = $user_storage->load($uid);
 
-          return $user;
+            return $user;
         } else if (count($entities) > 1) {
-          throw new \Exception(sprintf('Found more than one user named "%s"', $userName));
+            throw new \Exception(sprintf('Found more than one user named "%s"', $userName));
         } else {
-          throw new \Exception(sprintf('No user named "%s" exists', $userName));
+            throw new \Exception(sprintf('No user named "%s" exists', $userName));
         }
 
     }//end findUserByName()

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -30,8 +30,16 @@ class SharedDrupalContext extends RawDrupalContext
     /**
      * Get node object by its title.
      *
-     * @param string $contentType A Drupal content type machine name.
-     * @param string $title       The title of a Drupal node.
+     * @param string $contentType
+     *  A Drupal content type machine name.
+     * @param string $title
+     *  The title of a Drupal node.
+     * @param string $language
+     *  The language the node is in.
+     *
+     * @throws \Exception if no node with title $title was found.
+     * @throws \Exception if node is not available in that language.
+     * @throws \Exception if multiple nodes with title $title are found.
      *
      * @return stdclass
      *   The Drupal node object, if it exists.

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -227,7 +227,7 @@ class SharedDrupalContext extends RawDrupalContext
         $query = \Drupal::entityQuery('media');
 
         $entities = $query
-            ->condition('type', $mediaType)
+            ->condition('bundle', $mediaType)
             ->condition('info', $name)
             ->execute();
 

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -204,6 +204,59 @@ class SharedDrupalContext extends RawDrupalContext
 
 
     /**
+     * Get media object by its name.
+     *
+     * @param string $mediaType
+     *  A Drupal media type machine name.
+     * @param string $name
+     *  The name of a Drupal media entity.
+     * @param string $language
+     *  Optional language code.
+     *
+     * @throws \Exception if media is not found.
+     * @throws \Exception if multiple media entities with name $name are found.
+     *
+     * @return \Drupal\media\Entity\Media|bool
+     *  The Drupal media object, if it exists or FALSE.
+     */
+    public function findMediaByName($mediaType, $name, $language = NULL)
+    {
+        /**
+         * @var $query \Drupal\Core\Entity\Query\QueryInterface
+         */
+        $query = \Drupal::entityQuery('media');
+
+        $entities = $query
+            ->condition('type', $mediaType)
+            ->condition('info', $name)
+            ->execute();
+
+        if (count($entities) === 1) {
+            $block_storage = \Drupal::entityTypeManager()->getStorage('media');
+            $id = array_shift($entities);
+
+            $media = $block_storage->load($id);
+
+            if (!is_null($language)) {
+                if ($media->hasTranslation($language)) {
+                    $media = $media->getTranslation($language);
+                }
+                else {
+                    throw new \Exception('The media entity is not available in that language.');
+                }
+            }
+
+            return $media;
+        } else if (count($entities) > 1) {
+            throw new \Exception(sprintf('Found more than one "%s" media entity with name "%s"', $mediaType, $name));
+        } else {
+            throw new \Exception(sprintf('No "%s" media entities with name "%s" exists', $mediaType, $name));
+        }
+
+    }//end findMediaByName()
+
+
+    /**
      * Get a user object by name.
      *
      * @param string $userName The name of a Drupal user.

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -228,7 +228,7 @@ class SharedDrupalContext extends RawDrupalContext
 
         $entities = $query
             ->condition('bundle', $mediaType)
-            ->condition('info', $name)
+            ->condition('name', $name)
             ->execute();
 
         if (count($entities) === 1) {

--- a/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
+++ b/src/Palantirnet/PalantirBehatExtension/Context/SharedDrupalContext.php
@@ -61,12 +61,12 @@ class SharedDrupalContext extends RawDrupalContext
             $node = $node_storage->load($nid);
 
             if (!is_null($language)) {
-              if ($node->hasTranslation($language)) {
-                $node = $node->getTranslation($language);
-              }
-              else {
-                throw new \Exception('The node is not available in that language.');
-              }
+                if ($node->hasTranslation($language)) {
+                    $node = $node->getTranslation($language);
+                }
+                else {
+                    throw new \Exception('The node is not available in that language.');
+                }
             }
 
             return $node;
@@ -97,10 +97,10 @@ class SharedDrupalContext extends RawDrupalContext
         }
         catch (\Exception $e) {
             $new_node = (object) array(
-                                  'title' => $title,
-                                  'type'  => $contentType,
-                                  'body'  => $this->getRandom()->string(255),
-                                 );
+                'title' => $title,
+                'type'  => $contentType,
+                'body'  => $this->getRandom()->string(255),
+            );
 
             $node = $this->nodeCreate($new_node);
         }
@@ -150,8 +150,8 @@ class SharedDrupalContext extends RawDrupalContext
      * @throws \Exception if user is not found.
      * @throws \Exception if multiple user with name $userName are found.
      *
-     * @return \Drupal\Core\Entity\EntityInterface
-     *   The Drupal user object, if it exists.
+     * @return \Drupal\User\Entity\User|bool
+     *   A Drupal user object or FALSE if it does not exist.
      */
     public function findUserByName($userName)
     {
@@ -242,9 +242,9 @@ class SharedDrupalContext extends RawDrupalContext
 
         // Add default values.
         $defaults = array(
-                     'uid'    => 0,
-                     'status' => 1,
-                    );
+            'uid'    => 0,
+            'status' => 1,
+        );
 
         foreach ($defaults as $key => $default) {
             if (isset($file->$key) === false) {


### PR DESCRIPTION
## What, Why?

- [ ] Added support for custom blocks in D8:
`When I examine the :blockType block with info :info`
`When I examine the "block" block with info "Footer block"`

- [ ] Added support for block translations:
`When I examine the :blockType block with info :info in :language`
`When I examine the "block" block with info "Footer block" in "en"`

- [ ] Refactored entity field function to support custom properties:
`Then entity field :field should contain :value for property :property`
`Then entity field "field_website_url" should contain "https://www.google.com" for property "uri"`
`Then entity field "field_address_field" should contain "US" for property "country_code"`

## Dependencies
https://github.com/palantirnet/palantir-behat-extension/pull/36 should be merged in first