### PR TITLE
Update drupal/drupal-extension to 4.x for Drupal 9 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "drupal/drupal-extension": "3.*"
+        "drupal/drupal-extension": "4.*"
     },
     "repositories": [
         {


### PR DESCRIPTION
This is a super quick change and will allow this project to be D9 compatible. Tested via a fork on https://github.com/palantirnet/ntc and Behat tests still run perfecty when when the `drupal/drupal-extension` package is updated to `4.*`.